### PR TITLE
wirego_remote(rust): Introduce logger

### DIFF
--- a/.github/workflows/rust-ubuntu.yml
+++ b/.github/workflows/rust-ubuntu.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches: ["main"]
     # examples could be run in the other job after this one passes
-    paths: [".github/workflows/rust-ubuntu.yml", "wirego_remote/rust/wirego"]
+    paths: [".github/workflows/rust-ubuntu.yml", "wirego_remote/rust/wirego/**"]
   pull_request:
     branches: ["main"]
-    paths: [".github/workflows/rust-ubuntu.yml", "wirego_remote/rust/wirego"]
+    paths: [".github/workflows/rust-ubuntu.yml", "wirego_remote/rust/wirego/**"]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust-ubuntu.yml
+++ b/.github/workflows/rust-ubuntu.yml
@@ -26,6 +26,10 @@ jobs:
         run: cargo build --verbose
         working-directory: ${{ env.working-directory }}
 
+      - name: Check the formatting of the code
+        run: cargo fmt --all -- --check
+        working-directory: ${{ env.working-directory }}
+
       - name: Check the package and dependencies for errors
         run: cargo check --verbose
         working-directory: ${{ env.working-directory }}

--- a/wirego_remote/rust/wirego/Cargo.lock
+++ b/wirego_remote/rust/wirego/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -88,6 +88,16 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -115,6 +125,15 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -242,6 +261,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,8 +317,14 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -296,6 +333,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -333,7 +379,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -347,6 +393,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -462,12 +514,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simple_logger"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c5dfa5e08767553704aa0ffd9d9794d527103c736aba9854773851fd7497eb"
+dependencies = [
+ "colored",
+ "log",
+ "time",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -492,7 +576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -527,6 +611,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tokio"
 version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,7 +658,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -601,11 +718,35 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -614,15 +755,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -632,9 +779,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -650,9 +809,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -662,9 +833,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -679,6 +862,7 @@ dependencies = [
  "bytes",
  "futures",
  "log",
+ "simple_logger",
  "tokio",
  "zeromq",
 ]

--- a/wirego_remote/rust/wirego/Cargo.toml
+++ b/wirego_remote/rust/wirego/Cargo.toml
@@ -10,6 +10,9 @@ futures = "0.3.31"
 bytes = "1.10.1"
 tokio = "1.45.0"
 
+[dev-dependencies]
+simple_logger = "5.0.0"
+
 [[example]]
 name = "minimal"
 path = "examples/minimal/main.rs"

--- a/wirego_remote/rust/wirego/examples/minimal/main.rs
+++ b/wirego_remote/rust/wirego/examples/minimal/main.rs
@@ -1,20 +1,29 @@
+use log::{LevelFilter, error, info};
+use simple_logger::SimpleLogger;
 use tokio;
 use wirego::{Wirego, WiregoListener};
 
 #[tokio::main]
 async fn main() {
-    println!("Wirego Minimal Example");
-    println!("=========================");
-    println!("This is a minimal example of a Wirego dissector.");
+    // Instantiate a simple logger
+    SimpleLogger::new()
+        .with_level(LevelFilter::Info)
+        .with_module_level("wirego", LevelFilter::Warn)
+        .init()
+        .unwrap();
+
+    info!("Wirego Minimal Example");
+    info!("=========================");
+    info!("This is a minimal example of a Wirego dissector.");
 
     // Create our listener
     let minimal_listener = Box::new(WiregoMinimalListener);
-    println!("minimal listener name: {}", minimal_listener.get_name());
+    info!("Listener name: {}", minimal_listener.get_name());
 
     // Instantiate Wirego with the listener
     let wirego = Wirego::new("ipc:///tmp/wirego0", minimal_listener).await;
     if wirego.is_err() {
-        eprintln!("Error: {}", wirego.err().unwrap());
+        error!("Error: {}", wirego.err().unwrap());
         return;
     }
 
@@ -22,7 +31,7 @@ async fn main() {
 
     // Start listening on given ZMQ socket
     if let Err(error) = wirego.listen().await {
-        eprintln!("Error: {}", error);
+        error!("Error: {}", error);
     };
 }
 

--- a/wirego_remote/rust/wirego/src/zmq_utils.rs
+++ b/wirego_remote/rust/wirego/src/zmq_utils.rs
@@ -1,6 +1,7 @@
-use zeromq::{Socket, SocketRecv, SocketSend};
-
 use crate::error::WiregoError;
+
+use log::{debug, error, info};
+use zeromq::{Socket, SocketRecv, SocketSend};
 
 pub(crate) async fn bind_zmq_socket(zmq_endpoint: &str) -> Result<zeromq::RepSocket, WiregoError> {
     if zmq_endpoint.is_empty() {
@@ -18,11 +19,11 @@ pub(crate) async fn bind_zmq_socket(zmq_endpoint: &str) -> Result<zeromq::RepSoc
     let mut zmq_socket = zeromq::RepSocket::new();
     match zmq_socket.bind(zmq_endpoint).await {
         Ok(_) => {
-            println!("Wirego bridge is ready to receive commands!");
+            info!("Wirego bridge is ready to receive commands!");
             Ok(zmq_socket)
         }
         Err(err) => {
-            eprintln!("Failed to bind to endpoint: {:?}", err);
+            error!("Failed to bind to endpoint: {:?}", err);
             Err(WiregoError::SocketBindError(err.to_string()))
         }
     }
@@ -34,7 +35,7 @@ pub(crate) async fn receive_zmq_message(
     match zmq_socket.recv().await {
         Ok(zmq_message) => Ok(zmq_message),
         Err(err) => {
-            eprintln!("Failed to receive ZMQ message: {:?}", err);
+            error!("Failed to receive ZMQ message: {:?}", err);
             Err(WiregoError::SocketReceiveError(err.to_string()))
         }
     }
@@ -44,11 +45,11 @@ pub(crate) async fn send_zmq_message(
     zmq_socket: &mut zeromq::RepSocket,
     zmq_message: zeromq::ZmqMessage,
 ) -> Result<(), WiregoError> {
-    println!("Sending ZMQ message: {:?}", zmq_message);
+    debug!("Sending ZMQ message: {:?}", zmq_message);
     match zmq_socket.send(zmq_message).await {
         Ok(_) => Ok(()),
         Err(err) => {
-            eprintln!("Failed to send ZMQ message: {:?}", err);
+            error!("Failed to send ZMQ message: {:?}", err);
             Err(WiregoError::SocketSendError(err.to_string()))
         }
     }


### PR DESCRIPTION
As we talked recently, better logging was one of the points that I was meant to work on :) 

Since wirego is a crate that is later used in binaries (aka implemented plugins), it does not instantiate a logger by itself, but uses `log` crate and lets the user use any logging frontend (you may see changes in both the wirego crate and the example). That is the behavior that is recommended:

- https://www.reddit.com/r/rust/comments/qifji5/how_to_use_logging_in_a_library_crate/
- https://docs.rs/log/latest/log/

If we wanted to initialize the logger in the crate, we could potentially break the plugin if the user wanted to use some different logging frontend, thus that's probably the best solution - safe and allowing users to do anything they want (including having no logs at all).