### PR TITLE
Fix heuristic detection

### DIFF
--- a/wirego_bridge/zmq_relay.c
+++ b/wirego_bridge/zmq_relay.c
@@ -527,7 +527,7 @@ int wirego_process_heuristic(wirego_t* wirego_h, int packet_number, char* src, c
   detection_result = b;
 
   ws_noisy("process_heuristic %d", detection_result);
-  return detection_result;
+  return detection_result==1?0:-1;
 }
 
 int wirego_process_dissect_packet(wirego_t* wirego_h, int packet_number, char* src, char* dst, char* layer, const char* packet, int packet_size) {


### PR DESCRIPTION
ZMQ layer returns a bool (0/1) when the C function is expected to return -1 (no detection) or 0 (detection)

Closes #49 